### PR TITLE
Move babel-core to dependencies to work with build_production_resources

### DIFF
--- a/shuup_cms_blog/package.json
+++ b/shuup_cms_blog/package.json
@@ -14,6 +14,7 @@
   "license": "OSL-3.0",
   "dependencies": {
     "autoprefixer": "^8.6.4",
+    "babel-core": "^6.26.3",
     "babel-preset-env": "^1.7.0",
     "parcel-bundler": "^1.10.3",
     "postcss-modules": "^1.1.0",
@@ -23,8 +24,5 @@
   "browsertlist": [
     "> 1%",
     "last 5 versions"
-  ],
-  "devDependencies": {
-    "babel-core": "^6.26.3"
-  }
+  ]
 }


### PR DESCRIPTION
:warning: Needs Shuup update to PyPI (version >=1.7.4)