### PR TITLE
Add multiple blog functionality

### DIFF
--- a/shuup_cms_blog/forms.py
+++ b/shuup_cms_blog/forms.py
@@ -15,10 +15,9 @@ class BlogConfigForm(GenericPluginForm):
     def populate(self):
         super(BlogConfigForm, self).populate()
         self.fields["blog_page"] = XThemeModelChoiceField(
-            label=_("Blog page"),
-            queryset=Page.objects.filter(children__blog_article__is_blog_article=True).distinct(),
-            required=False,
-        )
+            label=_("Blog page"), queryset=Page.objects.filter(
+                children__blog_article__is_blog_article=True).distinct().visible(
+                self.request.shop), required=False)
 
     def clean(self):
         cleaned_data = super(BlogConfigForm, self).clean()

--- a/shuup_cms_blog/forms.py
+++ b/shuup_cms_blog/forms.py
@@ -1,0 +1,27 @@
+# This file is part of Shuup CMS Blog Addon.
+#
+# Copyright (c) 2012-2019, Shuup Inc. All rights reserved.
+#
+# This source code is licensed under the OSL-3.0 license found in the
+# LICENSE file in the root directory of this source tree.
+from django.utils.translation import ugettext_lazy as _
+
+from shuup.simple_cms.models import Page
+from shuup.xtheme.plugins.forms import GenericPluginForm
+from shuup.xtheme.plugins.widgets import XThemeModelChoiceField
+
+
+class BlogConfigForm(GenericPluginForm):
+    def populate(self):
+        super(BlogConfigForm, self).populate()
+        self.fields["blog_page"] = XThemeModelChoiceField(
+            label=_("Blog page"),
+            queryset=Page.objects.filter(children__blog_article__is_blog_article=True).distinct(),
+            required=False,
+        )
+
+    def clean(self):
+        cleaned_data = super(BlogConfigForm, self).clean()
+        blog_page = cleaned_data.get("blog_page")
+        cleaned_data["blog_page"] = blog_page.pk if hasattr(blog_page, "pk") else None
+        return cleaned_data

--- a/shuup_cms_blog/locale/en/LC_MESSAGES/django.po
+++ b/shuup_cms_blog/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2019-05-21 21:03+0000\n"
+"POT-Creation-Date: 2019-09-12 21:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,6 +18,9 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 msgid "Saved Articles"
+msgstr ""
+
+msgid "Blog page"
 msgstr ""
 
 msgid "page"
@@ -64,6 +67,9 @@ msgid "Blog Article"
 msgstr ""
 
 msgid "Home"
+msgstr ""
+
+msgid "Related articles"
 msgstr ""
 
 msgid "Remove from saved articles"

--- a/shuup_cms_blog/plugins.py
+++ b/shuup_cms_blog/plugins.py
@@ -11,18 +11,35 @@ from shuup.simple_cms.models import Page
 from shuup.xtheme import TemplatedPlugin
 from shuup.xtheme.resources import add_resource
 
+from .forms import BlogConfigForm
+
 
 class ShuupCMSBlogArticleListPlugin(TemplatedPlugin):
     identifier = "shuup_cms_blog_articles_list"
     name = _("Blog Articles List")
     template_name = "shuup_cms_blog/plugins/article_list.jinja"
+    fields = [("blog_page", None)]
+    editor_form_class = BlogConfigForm
+
+    def get_defaults(self):
+        defaults = super(ShuupCMSBlogArticleListPlugin, self).get_defaults()
+        defaults.update({
+            "blog_page": self.config.get("blog_page", None)
+        })
+        return defaults
 
     def get_context_data(self, context):
         context = super(ShuupCMSBlogArticleListPlugin, self).get_context_data(context)
         request = context["request"]
-        context["articles"] = Page.objects.visible(request.shop).filter(
+        qs = Page.objects.visible(request.shop).filter(
             blog_article__is_blog_article=True
-        ).order_by("-available_from")
+        )
+        config_page_id = self.config.get("blog_page")
+        if config_page_id:
+            qs = qs.filter(parent__id=config_page_id)
+        else:
+            qs = qs.filter(parent__isnull=True)
+        context["articles"] = qs.order_by("-available_from")
         return context
 
     def render(self, context):

--- a/shuup_cms_blog/plugins.py
+++ b/shuup_cms_blog/plugins.py
@@ -29,11 +29,17 @@ class ShuupCMSBlogArticleListPlugin(TemplatedPlugin):
         return defaults
 
     def get_context_data(self, context):
+        page_obj = context.get("object")
         context = super(ShuupCMSBlogArticleListPlugin, self).get_context_data(context)
         request = context["request"]
         qs = Page.objects.visible(request.shop).filter(
             blog_article__is_blog_article=True
         )
+        if page_obj:
+            if isinstance(page_obj, Page) and hasattr(page_obj, 'blog_article'):
+                if page_obj.blog_article.is_blog_article:
+                    self.config["blog_page"] = page_obj.parent.pk if page_obj.parent else None
+                    qs = qs.exclude(id=page_obj.pk)  # Exclude active/visited blog article
         config_page_id = self.config.get("blog_page")
         if config_page_id:
             qs = qs.filter(parent__id=config_page_id)

--- a/shuup_cms_blog/templates/shuup_cms_blog/blog_page.jinja
+++ b/shuup_cms_blog/templates/shuup_cms_blog/blog_page.jinja
@@ -33,6 +33,10 @@
         {{ render_article_features(page) }}
         {% placeholder "blog_page_middle" %}{% endplaceholder %}
         {{ page.get_html()|safe }}
+        <h2>{% trans %}Related articles{% endtrans %}</h2>
+        {% placeholder "front_content" %}
+            {% plugin "shuup_cms_blog_articles_list" %}{% endplugin %}
+        {% endplaceholder %}
         {% placeholder "blog_page_footer" %}{% endplaceholder %}
     </div>
 {% endblock %}

--- a/shuup_cms_blog_tests/test_plugin.py
+++ b/shuup_cms_blog_tests/test_plugin.py
@@ -29,32 +29,42 @@ def test_plugin():
     shop = factories.get_default_shop()
     set_current_theme(ClassicGrayTheme.identifier, shop)
 
-    blog_page = Page.objects.create(
+    blog_one_page = Page.objects.create(
         shop=shop,
-        title="Blog",
-        url="blog",
+        title="Blog One",
+        url="blog_one",
         available_from=(now() - timedelta(days=10)),
         available_to=(now() + timedelta(days=10)),
         content=""
     )
 
+    blog_two_page = Page.objects.create(
+        shop=shop,
+        title="Blog Two",
+        url="blog_two",
+        available_from=(now() - timedelta(days=10)),
+        available_to=(now() + timedelta(days=10)),
+        content=""
+    )
     # create 10 blog pages
-    for i in range(10):
-        article = Page.objects.create(
-            shop=shop,
-            title="Article %d" % i,
-            url="blog-%d" % i,
-            available_from=(now() - timedelta(days=10)),
-            available_to=(now() + timedelta(days=10)),
-            content="Content %d" % i,
-            template_name="shuup_cms_blog/blog_page.jinja"
-        )
-        BlogArticle.objects.create(
-            page=article,
-            is_blog_article=True,
-            image=factories.get_random_filer_image(),
-            small_description="description %d" % i
-        )
+    for page in [blog_one_page, blog_two_page]:
+        for i in range(10):
+            article = Page.objects.create(
+                shop=shop,
+                title="Article %d %s" % (i, page.title),
+                url="blog-%d-%s" % (i, page.url),
+                available_from=(now() - timedelta(days=10)),
+                available_to=(now() + timedelta(days=10)),
+                content="Content %d" % i,
+                template_name="shuup_cms_blog/blog_page.jinja",
+                parent=page
+            )
+            BlogArticle.objects.create(
+                page=article,
+                is_blog_article=True,
+                image=factories.get_random_filer_image(),
+                small_description="description %d" % i
+            )
 
     # create 3 non blog post pages
     for i in range(3):
@@ -71,21 +81,77 @@ def test_plugin():
     view_config = ViewConfig(theme=theme, shop=shop, view_name="PageView", draft=True)
 
     placeholder_name = "cms_page"
-    context = {"page": blog_page}
-    layout = view_config.get_placeholder_layout(PageLayout, placeholder_name, context=context)
-    assert isinstance(layout, PageLayout)
-    assert layout.get_help_text({}) == ""
-    assert blog_page.title in layout.get_help_text(context)
-    serialized = layout.serialize()
-    assert len(serialized["rows"]) == 0
-    assert serialized["name"] == placeholder_name
+    context_one = {"page": blog_one_page}
+    context_two = {"page": blog_two_page}
 
-    layout.begin_column({"sm": 12})
-    layout.add_plugin(ShuupCMSBlogArticleListPlugin.identifier, {})
-    view_config.save_placeholder_layout(get_layout_data_key(placeholder_name, layout, context), layout)
+    layout_one = view_config.get_placeholder_layout(PageLayout, placeholder_name, context=context_one)
+    layout_two = view_config.get_placeholder_layout(PageLayout, placeholder_name, context=context_two)
+
+    assert isinstance(layout_one, PageLayout)
+    assert isinstance(layout_two, PageLayout)
+
+    assert layout_one.get_help_text({}) == ""
+    assert layout_two.get_help_text({}) == ""
+
+    assert blog_one_page.title in layout_two.get_help_text(context_one)
+    assert blog_two_page.title in layout_two.get_help_text(context_two)
+
+    serialized_one = layout_one.serialize()
+    serialized_two = layout_two.serialize()
+
+    assert len(serialized_one["rows"]) == 0
+    assert len(serialized_two["rows"]) == 0
+
+    assert serialized_one["name"] == placeholder_name
+    assert serialized_two["name"] == placeholder_name
+
+    layout_one.begin_column({"sm": 12})
+    layout_two.begin_column({"sm": 12})
+
+    layout_one.add_plugin(ShuupCMSBlogArticleListPlugin.identifier, {"blog_page": blog_one_page.pk})
+    layout_two.add_plugin(ShuupCMSBlogArticleListPlugin.identifier, {"blog_page": blog_two_page.pk})
+
+    view_config.save_placeholder_layout(get_layout_data_key(placeholder_name, layout_one, context_one), layout_one)
+    view_config.save_placeholder_layout(get_layout_data_key(placeholder_name, layout_two, context_two), layout_two)
     view_config.publish()
 
     client = SmartClient()
-    response, soup = client.response_and_soup(reverse("shuup:cms_page", kwargs={"url": blog_page.url}))
+    response, soup = client.response_and_soup(reverse("shuup:cms_page", kwargs={"url": blog_one_page.url}))
     assert response.status_code == 200
     assert len(soup.find_all("a", {"class": "article-card"})) == 10
+
+    response, soup = client.response_and_soup(reverse("shuup:cms_page", kwargs={"url": blog_two_page.url}))
+    assert response.status_code == 200
+    assert len(soup.find_all("a", {"class": "article-card"})) == 10
+
+    article = Page.objects.create(
+        shop=shop,
+        title="Article test",
+        url="blog-test",
+        available_from=(now() - timedelta(days=10)),
+        available_to=(now() + timedelta(days=10)),
+        content="Content test",
+        template_name="shuup_cms_blog/blog_page.jinja",  # Add an article without a parent
+    )
+    BlogArticle.objects.create(
+        page=article,
+        is_blog_article=True,
+        image=factories.get_random_filer_image(),
+        small_description="description test"
+    )
+    view_config = ViewConfig(theme=theme, shop=shop, view_name="PageView", draft=True)
+
+    # No blog page set means that only articles with no parent will be shown
+    layout_two.add_plugin(ShuupCMSBlogArticleListPlugin.identifier, {})
+    view_config.save_placeholder_layout(get_layout_data_key(placeholder_name, layout_two, context_two), layout_two)
+    view_config.publish()
+
+    response, soup = client.response_and_soup(reverse("shuup:cms_page", kwargs={"url": blog_two_page.url}))
+    assert response.status_code == 200
+    assert len(soup.find_all("a", {"class": "article-card"})) == 1
+
+    article.soft_delete()  # Delete the article that has no parent
+
+    response, soup = client.response_and_soup(reverse("shuup:cms_page", kwargs={"url": blog_two_page.url}))
+    assert response.status_code == 200
+    assert len(soup.find_all("a", {"class": "article-card"})) == 0


### PR DESCRIPTION
- Add multiple blog functionality
Enabled multiple blogs for Shuup CMS.
To set a blog for a blog article, just set the article parent to be that blog page.
Each separate parent page of blog article children represents a blog. A blog to be shown is chosen in xtheme Blog Article List plugin.
If no blog is chosen then blog articles with no parent will be shown instead.

Refs HEAL-66


- Add related articles to article pages
On blog article templates, in the bottom section with "Related articles" will show from now on.
It'll show article cards for articles which either have the same parent as the blog article that's being
read/visited or if the said article has no parents then it will show articles which have no parent as well.
![image](https://user-images.githubusercontent.com/40273438/64046133-59cc2100-cb6b-11e9-992d-0f07bbb9bbf8.png)

Refs HEAL-12
